### PR TITLE
Clarify accommodation distance from venue criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Do not, I repeat, **DO NOT** make a native app. Most of the people won't even bo
 
 # 🏨️ Accommodation
 
-* When the conference venue is in the hotel where the speakers are staying it's just _amazing_. Having access to your room in order to practice your talk, or go for a nap, or cry a bit because you agreed on doing a talk but you're having second thoughts ... it's just the best.
+* When the conference venue is in the hotel where the speakers are staying it's just _amazing_. If this isn't practical, then the venue and hotel should be within close walking distance. Having access to your room in order to practice your talk, or go for a nap, or cry a bit because you agreed on doing a talk but you're having second thoughts ... it's just the best.
 * Ask speakers if they want to stay on a boat? It sounds interesting but some people may not enjoy it.
 * Attempt not to split speakers in different hotels
 * Access to fitness equipment of some sort is always a nice bonus. Sometimes a conference will require a speaker to travel for almost a whole week. That's a long time to put off exercise.


### PR DESCRIPTION
The spirit of the bullet point is that the closer to the hotel the venue is, the better. I made this more explicit by adding a sentence to urge organizers to make sure that if the hotel is not also the venue, then the hotel should be easily walkable from the venue. A good litmus test here is if you see speakers sleeping face down on a table in the green room in the middle of the day (@lelandrichardson 👀).