### PR TITLE
Food suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ So many conferences got this wrong, and it's so simple. It shouldn't be anything
 
 ## 🍗 Food
 
-* The amount of food that you're planning? Just make it double. Don't underestimate the hunger of people. It can bring their mood down and they can judge the entire conference based on that.
-* Have a variety of food for breakfast and lunch. Assume there will be people will allergies and different food preferences (Vegetarians, Vegans, gluten free, Pescatarians, [Pesca-pescatarians](https://www.youtube.com/watch?v=IC-ZBJ-Kw2E), etc.). Clearly label any food intended for these groups and keep it separate if possible so that it doesn't get taken by those it isn't intended for.
+* Running out of food can make the conference a bad experience for attendees. If you can afford it, order extra lunches. If lunch is served during a short period of time, try to have packaged snacks that can sit out longer.
+* Have a variety of food for breakfast and lunch. Assume there will be people will allergies and different food preferences (Vegetarians, Vegans, gluten free, Pescatarians, [Pesca-pescatarians](https://www.youtube.com/watch?v=IC-ZBJ-Kw2E), etc.). Clearly label any food intended for these groups and keep it separate if possible so that it doesn't get taken by those it isn't intended for. If possible, ask for food preferences/restrictions during registration and set aside special food so it doesn't get taken on accident.
 * If people are paying more than 300 euros for the conference and your breakfast is just **one** croissant ... don't even get me started. Fix that.
 * If the weather is hot, have an ice-cream fridge. This was an amazing idea by the JSHeroes conference, and everyone enjoyed it 🍦️
-* React Rally gave everyone a prepaid debit card to spend at restaurants in the city and then the time for you to eat a good meal. It worked out as a great way to get to know the location and other people you went to lunch with.
+* React Rally gave everyone a prepaid debit card to spend at restaurants in the city and then the time for you to eat a good meal. It worked out as a great way to get to know the location and other people you went to lunch with. If you do this, you may need to extend your lunch period to give people time.
 * Schedule an early lunch for people who work at the sponsor booths. They also get hungry, but they can't leave the booth during the lunch break. And making them eat at the booth during the break is not cool either. 
 
 ## ⏰ Scheduling


### PR DESCRIPTION
1) Doubling your food purchase isn't feasible. Food is often 50-75% of the cost of a conference. At least in the US, most conference venues don't charge a ton for space and make all of their money on food. Source: I organize multiple events from 200 people to 2300+ people and see the costs directly. I've talked to other organizers about this in detail too.
2) Asking for food restrictions lets you order specialty things ahead of time and make sure the right people get them. I've had people eat the wrong meals and someone went without.
3) If you give people gift cards and they leave the conference venue to eat, it's going to take a while. A lot of conferences give way too much time for a lunch in the main conference room, but that turns into too little time if you have to sit down at a restaurant.